### PR TITLE
Updated wp-front-end-editor plugin for use with the latest version of Aloha Editor

### DIFF
--- a/coffee/aloha/wpImage-plugin.coffee
+++ b/coffee/aloha/wpImage-plugin.coffee
@@ -1,25 +1,18 @@
 # Plugin for integrating the WordPress media thickbox
 
-define [ 'aloha/plugin', 'aloha/floatingmenu', 'i18n!aloha/nls/i18n' ], (Plugin, FloatingMenu, i18nCore) ->
+define [ 'aloha/plugin', 'ui/ui', 'ui/button', 'i18n!aloha/nls/i18n' ], (Plugin, Ui, Button, i18nCore) ->
 	Aloha = window.Aloha
 
 	return Plugin.create('wpImage', {
 
 		init: ->
-			button = new Aloha.ui.Button({
-				'name' : 'wpImage',
-				'iconClass' : 'ImageWP',
-				'size' : 'small',
-				'onclick' : @insert,
-				'tooltip' : FrontEndEditor.data.image.insert
-			})
-
-			FloatingMenu.addButton(
-				'Aloha.continuoustext',
-				button,
-				i18nCore.t('floatingmenu.tab.insert'),
-				2
-			)
+			Ui.adopt('wpImage', Button, {
+		        'name': 'wpImage',
+		        'iconClass': 'ImageWP',
+		        'onclick': this.insert,
+		        'tooltip': i18nCore.t('floatingmenu.tab.insert'),
+		        'scope': 'Aloha.continuoustext'
+      		})
 
 		insert: ->
 			instance = new FrontEndEditor.fieldTypes.image_rich

--- a/php/core.php
+++ b/php/core.php
@@ -123,22 +123,30 @@ Aloha.settings = {
 </script>
 <?php
 	$plugins = array(
+		'common/ui',
 		'common/format',
 		'common/align',
 		'common/list',
 		'common/link',
 		'common/table',
 		'common/undo',
+		'common/contenthandler',
 		'common/paste',
 		'common/block',
 		'extra/cite',
-		'fee/wpImage',
+		'fee/wpImage'
 	);
+
+	// add require.js which is a prerequisite for Aloha Editor
+	echo html( 'script', array(
+		'src' => plugins_url( 'lib/aloha-editor/lib/require.js', FEE_MAIN_FILE )
+	) ) . "\n";
 
 	echo html( 'script', array(
 		'src' => plugins_url( 'lib/aloha-editor/lib/aloha.js', FEE_MAIN_FILE ),
 		'data-aloha-plugins' => implode( ',', $plugins )
 	) ) . "\n";
+
 }
 
 		scbUtil::do_scripts( self::$js_dependencies );


### PR DESCRIPTION
Now the plugin can be used with Aloha Editor 0.23.6
