### PR TITLE
Addresses issue #101

### DIFF
--- a/php/fields/base.php
+++ b/php/fields/base.php
@@ -33,7 +33,7 @@ abstract class FEE_Field_Base {
 	 *
 	 * @return string
 	 */
-	abstract public static function get_object_type();
+	public static function get_object_type() {}
 
 	/**
 	 * Optional actions to be done once per field type.
@@ -50,7 +50,7 @@ abstract class FEE_Field_Base {
 	 *
 	 * @return string Wrapped content
 	 */
-	public function wrap( $content, $data ) {
+	public function wrap( $content = null, $data = null ) {
 		if ( !$this->allow( $data ) )
 			return $content;
 

--- a/php/fields/other.php
+++ b/php/fields/other.php
@@ -7,7 +7,7 @@ class FEE_Field_Comment extends FEE_Field_Base {
 		return 'comment';
 	}
 
-	function wrap( $content ) {
+	function wrap( $content = null, $data = null ) {
 		global $comment;
 
 		$data = array( 'comment_id' => $comment->comment_ID );
@@ -68,7 +68,7 @@ class FEE_Field_Term_Field extends FEE_Field_Base {
 		$this->field = str_replace( 'term_', '', $this->filter );
 	}
 
-	function wrap( $content, $term_id, $taxonomy ) {
+	function wrap( $content = null, $data = null, $term_id = null, $taxonomy = null ) {
 		$data = compact( 'term_id', 'taxonomy' );
 
 		if ( !$this->check( $data ) )
@@ -113,7 +113,7 @@ class FEE_Field_Single_Title extends FEE_Field_Term_Field {
 		remove_filter( $this->filter, 'strip_tags' );
 	}
 
-	function wrap( $title ) {
+	function wrap( $content = null, $data = null, $term_id = null, $taxonomy = null, $title = null ) {
 		$term = get_queried_object();
 
 		return parent::wrap( $title, $term->term_id, $term->taxonomy );
@@ -128,7 +128,7 @@ class FEE_Field_Author_Desc extends FEE_Field_Base {
 		return 'user';
 	}
 
-	function wrap( $content, $author_id = '' ) {
+	function wrap( $content = null, $data = null, $author_id = '' ) {
 
 		if ( !$author_id )
 			$author_id = $GLOBALS['authordata']->ID;
@@ -177,7 +177,7 @@ class FEE_Field_Bloginfo extends FEE_Field_Base {
 		return 'option';
 	}
 
-	function wrap( $content, $show ) {
+	function wrap( $content = null, $data = null, $show = '' ) {
 		if ( !$this->check() )
 			return $content;
 
@@ -229,7 +229,7 @@ class FEE_Field_Option extends FEE_Field_Base {
 		$wpdb->query( "DELETE FROM $wpdb->options WHERE option_name LIKE 'editable!_option!_%' ESCAPE '!'" );
 	}
 
-	function wrap( $content, $key, $ui ) {
+	function wrap( $content = null, $data = null, $key = null, $ui = null ) {
 		$data = compact( 'key', 'ui' );
 
 		if ( !$this->check( $data ) )
@@ -295,7 +295,7 @@ class FEE_Field_Image extends FEE_Field_Base {
 		$wpdb->query( "DELETE FROM $wpdb->options WHERE option_name LIKE 'editable!_image!_%' ESCAPE '!'" );
 	}
 
-	function wrap( $img, $key ) {
+	function wrap( $content = null, $data = null, $img = null, $key = null ) {
 		if ( !$this->check() )
 			return $img;
 

--- a/php/fields/post.php
+++ b/php/fields/post.php
@@ -26,7 +26,7 @@ abstract class FEE_Field_Post extends FEE_Field_Base {
 		return str_replace( '"post-edit-link', '"post-edit-link fee-edit-button', $link );
 	}
 
-	function wrap( $content, $post_id = 0 ) {
+	function wrap( $content = null, $data = null, $post_id = 0 ) {
 		if ( !$post_id = $this->_get_id( $post_id ) ) {
 			return $content;
 		}
@@ -179,7 +179,7 @@ class FEE_Field_Post_Excerpt extends FEE_Field_Post {
 // Handles the_terms field
 class FEE_Field_Terms extends FEE_Field_Post {
 
-	function wrap( $content, $taxonomy, $before, $sep, $after ) {
+	function wrap( $content = null, $data = null, $taxonomy = null, $before = null, $sep = null, $after = null ) {
 		global $post;
 
 		if ( !in_the_loop() ) {
@@ -278,7 +278,7 @@ class FEE_Field_Terms extends FEE_Field_Post {
 // Handles the_tags field
 class FEE_Field_Tags extends FEE_Field_Terms {
 
-	function wrap( $content, $before, $sep, $after ) {
+	function wrap( $content = null, $data = null, $taxonomy = null, $before = null, $sep = null, $after = null ) {
 		return parent::wrap( $content, 'post_tag', $before, $sep, $after );
 	}
 }
@@ -287,8 +287,8 @@ class FEE_Field_Tags extends FEE_Field_Terms {
 // Handles the_category field
 class FEE_Field_Category extends FEE_Field_Terms {
 
-	function wrap( $content, $sep, $parents ) {
-		return parent::wrap( $content, 'category', '', $sep, '' );
+	function wrap( $content = null, $data = null, $before = null, $sep = null, $after = null, $parents = null ) {
+		return parent::wrap( $content, 'category', '', $sep, $after, '' );
 	}
 }
 
@@ -296,12 +296,12 @@ class FEE_Field_Category extends FEE_Field_Terms {
 // Handles the post thumbnail
 class FEE_Field_Post_Thumbnail extends FEE_Field_Post {
 
-	function wrap( $html, $post_id, $post_thumbnail_id, $size ) {
+	function wrap( $content = null, $data = null, $html = null, $post_id = null, $post_thumbnail_id = null, $size = null ) {
 		if ( !$post_id = $this->_get_id( $post_id, false ) ) {
 			return $html;
 		}
 
-		return FEE_Field_Base::wrap( $this->placehold( $html ), compact( 'post_id', 'size' ) );
+		return FEE_Field_Base::wrap( $content, $data, $this->placehold( $html ), compact( 'post_id', 'size' ) );
 	}
 
 	function get( $data ) {
@@ -349,7 +349,7 @@ class FEE_Field_Post_Meta extends FEE_Field_Post {
 		return $data;
 	}
 
-	function wrap( $data, $post_id, $key, $ui, $single ) {
+	function wrap( $content = null, $data = null, $post_id = null, $key = null, $ui = null, $single = null ) {
 		if ( $this->check( $post_id ) ) {
 			if ( $single ) {
 				$data = array( $this->placehold( $data ) );
@@ -357,7 +357,7 @@ class FEE_Field_Post_Meta extends FEE_Field_Post {
 
 			$r = array();
 			foreach ( $data as $i => $val ) {
-				$r[$i] = FEE_Field_Base::wrap( $val, compact( 'post_id', 'key', 'ui', 'i' ) );
+				$r[$i] = FEE_Field_Base::wrap( $content, $data, compact( 'post_id', 'key', 'ui', 'i' ) );
 			}
 		}
 		else {

--- a/php/fields/widget.php
+++ b/php/fields/widget.php
@@ -7,7 +7,7 @@ class FEE_Field_Widget extends FEE_Field_Base {
 		return 'widget';
 	}
 
-	function wrap( $params ) {
+	function wrap( $content = null, $data = null, $params = null ) {
 		if ( !$this->check() )
 			return $params;
 
@@ -104,7 +104,7 @@ class FEE_Field_Widget_Text extends FEE_Field_Widget {
 		$this->field = str_replace( 'widget_', '', $this->filter );
 	}
 
-	function wrap( $content, $instance = null, $id_base = null ) {
+	function wrap( $content = null, $data = null, $instance = null, $id_base = null ) {
 		// Only target text widgets
 		if ( 'title' == $this->field && ( !$id_base || 'text' != $id_base ) )
 			return $content;


### PR DESCRIPTION
So I'm not even sure if this was the proper way to address the Strict errors in WP, but it seems to have worked...except for the issues outlined [on WP support](http://wordpress.org/support/topic/attempting-to-fix-the-strict-errors-in-debug-mode?replies=3#post-5078437) and [StackExchange](http://wordpress.stackexchange.com/questions/128701/working-on-fixing-wp-front-end-editor-encountering-undefined-index). The widget wrapper throws an error when turned on, and still interferes with markup when it's turned off.

Original commit messages below.

---

Sets default values for wrap() function to quiet the strict errors when WP
is in debug mode.

Squashed commit of the following:

commit 77c0b93e73fce98f6fbe63334dfd3696e049b993
Author: Vincent Maglione vincent@bigsweaterdesign.com
Date:   Fri Jan 3 16:50:30 2014 -0500

```
Sets default values for wrap() in other.php
```

commit 8c59b7e9a5b12b64955f077715b70802f80b44d6
Author: Vincent Maglione vincent@bigsweaterdesign.com
Date:   Fri Jan 3 16:42:19 2014 -0500

```
Sets default values for wrap() in widget.php
```

commit 3dda0c8bf0b185be876f57075326c3f4a9c40477
Author: Vincent Maglione vincent@bigsweaterdesign.com
Date:   Fri Jan 3 16:39:20 2014 -0500

```
Sets default values for wrap() in post.php
```
