### PR TITLE
Remove trailing comma in JS object literal

### DIFF
--- a/php/core.php
+++ b/php/core.php
@@ -113,7 +113,7 @@ Aloha.settings = {
 	},
 	plugins: {
 		format: {
-			config: ['b', 'i', 'del', 'sub', 'sup', 'p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'pre', 'removeFormat'],
+			config: ['b', 'i', 'del', 'sub', 'sup', 'p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'pre', 'removeFormat']
 		}
 	}
 };


### PR DESCRIPTION
For compatability with IE <= 8. cf http://www.2ality.com/2013/07/trailing-commas.html
